### PR TITLE
fix geometry type mismatch on output of ST_MakeValid

### DIFF
--- a/t-rex-core/src/datasource/postgis_ds.rs
+++ b/t-rex-core/src/datasource/postgis_ds.rs
@@ -293,13 +293,10 @@ impl PostgisDatasource {
                     layer.tolerance(zoom)
                 ),
                 "POLYGON" | "MULTIPOLYGON" | "CURVEPOLYGON" => {
-                    let empty_geom =
-                        format!("ST_GeomFromText('MULTIPOLYGON EMPTY',{})", layer_srid);
                     format!(
-                        "COALESCE(ST_MakeValid(ST_SnapToGrid({}, {})),{})::geometry(MULTIPOLYGON,{})",
+                        "ST_CollectionExtract(ST_MakeValid(ST_SnapToGrid({}, {})),3)::geometry(MULTIPOLYGON,{})",
                         geom_expr,
                         layer.tolerance(zoom),
-                        empty_geom,
                         layer_srid
                     )
                 }


### PR DESCRIPTION
See issue https://github.com/t-rex-tileserver/t-rex/issues/206.

Output of ST_MakeValid produces linestrings as a result of collapsed polygons. Calling http://postgis.net/docs/ST_CollectionExtract.html  on the resultset of ST_MakeValid ensures that only POLYGON typed geometries are returned. 